### PR TITLE
Bump mrml from 3.1.5 to 4.0.0 in /native/mjml_nif

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ I.e. `mjml_nif 0.x` versions use mrml versions `>= 0.1, < 1.0.0`, and `mjml_nif 
 
 ## [Unreleased]
 
+## [4.0.0] - 2024-06-18
+
+- Use [mrml] v4.0.0 which fixes a bug when using HEEx annotations and phoenix function components to generate MJML (see [mrml diff v3.1.5..v4.0.0][mrml-v3.1.5-v4.0.0])
+
 ## [3.1.0] - 2024-04-18
 
 - Use [mrml] v3.1.5 (see [mrml diff v3.0.4..v3.1.5][mrml-v3.0.4-v3.1.5])

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Mjml.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/adoptoposs/mjml_nif"
-  @version "3.1.0"
+  @version "4.0.0"
 
   def project do
     [

--- a/native/mjml_nif/Cargo.toml
+++ b/native/mjml_nif/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mjml_nif"
-version = "3.1.0"
+version = "4.0.0"
 authors = ["Paul Götze"]
 edition = "2021"
 
@@ -11,7 +11,11 @@ crate-type = ["cdylib"]
 
 [dependencies]
 rustler = "0.33.0"
-mrml = { version = "3.1", default-features = false, features = ["parse", "render", "orderedmap"] }
+mrml = { version = "4.0.0", default-features = false, features = [
+    "parse",
+    "render",
+    "orderedmap",
+] }
 
 [features]
 default = ["nif_version_2_15"]


### PR DESCRIPTION
Version 4.0.0 fixes a bug if you use phoenix function components
to generate MJML and have heex annotations enabled by default.

Essentially the heex annotations add comments outside the <mjml> tag
and this was breaking the pareser.  The bug has been fixed upstream.

See https://github.com/jdrouet/mrml/issues/409 for more info.
